### PR TITLE
Adding category others to pie chart

### DIFF
--- a/src/components/LicensePie.js
+++ b/src/components/LicensePie.js
@@ -38,11 +38,22 @@ export default function LicensePie() {
     const [state, setState] = useState(config)
 
     useEffect(() => {
+        
+        const otherLicenses = _.takeRight(  licenses.length - 5, licenses)
+        const sumYOthers = _.sum( otherLicenses.map(obj=>parseInt(obj.count,10)))
+
+        const others = {
+            "name":"others",
+            "y": sumYOthers
+        }
+
         const series = _.pipe(
             _.map(_.mapKeys((k) => (k === "license" ? "name" : "y"))),
             _.map(_.update("y")(Math.floor)),
             _.take(5)
         )(licenses)
+
+        series.push(others)
         setState({ ...config, series: [{ data: series }] })
     }, [])
 


### PR DESCRIPTION
The pie chart represents the top 5 open source licenses, the other licenses are not considered. These licenses also represent a percentage of the github repositories, so they should be taken into account. 
So I added an other category taking in account these licenses to the pie chart. 