### PR TITLE
Fix arrows + Update FontAwesome to 6.1.1

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,8 +8,11 @@
             content="This website shows the popularity of programming languages on GitHub over time."
         />
         <title>GitHub Language Stats</title>
-        <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/fontawesome.min.css" as="style">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/fontawesome.min.css">
+        <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/fontawesome.min.css" as="style">
+        <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/solid.min.css" as="style">
+
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/fontawesome.min.css">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/solid.min.css">
     </head>
     <style>
         html {
@@ -170,19 +173,6 @@
         .emptyTable {
             margin-top: 200px;
             margin-bottom: 200px;
-        }
-
-        @font-face {
-            font-display: swap;
-        }
-
-        .fa {
-            display: inline-block;
-            font: normal normal normal 14px/1 FontAwesome;
-            font-size: inherit;
-            text-rendering: auto;
-            -webkit-font-smoothing: antialiased;
-            -moz-osx-font-smoothing: grayscale;
         }
 
         .react-bs-table table {

--- a/src/components/LangTable.js
+++ b/src/components/LangTable.js
@@ -70,7 +70,7 @@ export default function LangTable({store, hist, table}) {
      */
     function trendFormatter(cell, _) {
         const arrow = (n) => {
-            const angle = (dir) => `<i class='fa fa-angle-${dir}'></i>`
+            const angle = (dir) => `<i class='fas fa-angle-${dir}'></i>`
             switch (true) {
                 case n === 0:
                     return ""


### PR DESCRIPTION
There's a problem with arrows. This PR fixes it.

![image](https://user-images.githubusercontent.com/50925676/168271537-83522850-ab1c-44d0-a192-d181255e2b93.png)
